### PR TITLE
Implement IPv4 options parsing and gfx clipping

### DIFF
--- a/kernel/cbits/gfx.c
+++ b/kernel/cbits/gfx.c
@@ -142,12 +142,15 @@ unsigned get_pixel(int x,int y,unsigned undef)
 
 void fill_rectangle(int x0,int y0,int w,int h)
 {
-  int x,y;
+  int x1=x0, y1=y0, x2=x0+w, y2=y0+h, x,y;
   hide_cursor();
-  /* TODO: compute intersection with clip rectangle */
-  for(y=y0;y<y0+h;y++)
-    for(x=x0;x<x0+w;x++)
-      setpixel(x,y);
+  if(x1<clip.xmin) x1=clip.xmin;
+  if(y1<clip.ymin) y1=clip.ymin;
+  if(x2>clip.xmax) x2=clip.xmax;
+  if(y2>clip.ymax) y2=clip.ymax;
+  for(y=y1;y<y2;y++)
+    for(x=x1;x<x2;x++)
+      setpixelclip(x,y,&clip);
   show_cursor();
 }
 

--- a/tests/IPv4OptionsTest.hs
+++ b/tests/IPv4OptionsTest.hs
@@ -1,0 +1,15 @@
+import Net.IPv4
+import Net.PacketParsing
+import Net.Packet
+import Kernel.Bits
+import Data.Array.Unboxed
+
+main :: IO ()
+main = case doParse parse packet of
+         Just p  -> print (options (p :: Packet InPacket))
+         Nothing -> putStrLn "parse failed"
+  where
+    packet = toInPack (listArray (0,length bytes-1) bytes)
+    bytes = [0x46,0x00,0x00,0x18,0x00,0x01,0x00,0x00,64,17,0,0,
+             192,168,0,1,192,168,0,2,1,1,0,0]
+

--- a/tests/gfx_test.c
+++ b/tests/gfx_test.c
@@ -1,0 +1,24 @@
+#include "gfx.h"
+#include <stdio.h>
+#include <string.h>
+
+static unsigned char framebuffer[1000];
+static vbe_modeinfoblock_t mib = {0};
+static vbe_controlinfoblock_t cib = {0};
+
+int main() {
+    mib.x_resolution = 10;
+    mib.y_resolution = 10;
+    mib.bits_per_pixel = 8;
+    mib.phys_base_ptr = (unsigned int)(framebuffer);
+    init_gfx(&mib,&cib);
+    set_color(0xff,0,0);
+    set_clip(2,2,8,8);
+    fill_rectangle(0,0,10,10);
+    int count=0;
+    for(int y=0;y<10;y++)
+        for(int x=0;x<10;x++)
+            if(framebuffer[y*10+x]) count++;
+    printf("pixels=%d\n",count);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- parse IPv4 options into structured `Option` values
- support unparse of options when building IPv4 packets
- clip rectangles in `fill_rectangle`
- add small demo/test programs for IPv4 options and gfx

## Testing
- `gcc -Ikernel/cbits -c tests/gfx_test.c -o tests/gfx_test.o`
- `gcc -Ikernel/cbits tests/gfx_test.o kernel/cbits/gfx.c -o tests/gfx_test` *(fails at runtime: segmentation fault)*