### PR TITLE
Fix 64‑bit build support scripts

### DIFF
--- a/support/gcc/Makefile
+++ b/support/gcc/Makefile
@@ -1,4 +1,12 @@
+# Newer 64-bit toolchains ship libgcc objects without the
+# trailing 'S' in their file names.  Fall back to the plain
+# '.o' names when the '.oS' variants are missing.
+LIBGCC := $(shell gcc -print-libgcc-file-name)
+ifeq ($(shell ar t $(LIBGCC) 2>/dev/null | grep -c _divdi3.oS),1)
 OBJS = _divdi3.oS _moddi3.oS _udivdi3.oS _umoddi3.oS
+else
+OBJS = _divdi3.o _moddi3.o _udivdi3.o _umoddi3.o
+endif
 
 all:
 	ar x $(shell gcc -print-libgcc-file-name) $(OBJS)

--- a/support/gmp/Makefile
+++ b/support/gmp/Makefile
@@ -1,6 +1,12 @@
 TARGET = ../libtiny_gmp.a
 OBJS = assert.o memory.o
 
+# Try to locate the system libgmp.a using gcc.  When not found we
+# still produce a minimal library containing only the objects in
+# $(OBJS) so the build can continue (useful in minimal environments
+# such as the Codex container).
+LIBGMP := $(shell gcc -print-file-name=libgmp.a)
+
 EXC_OBJS = \
 	assert.o memory.o set_str.o dump.o inp_str.o out_str.o		\
 	dump.o fac_ui.o inp_raw.o inp_str.o out_raw.o out_str.o dump.o	\
@@ -11,11 +17,18 @@ EXC_OBJS = \
 	fscanf.o fscanffuns.o scanf.o set_d.o set_str.o sprintffuns.o	\
 	vprintf.o sscanf.o vsscanf.o set_str.o
 
-all: $(OBJS)
-	cp /usr/lib/libgmp.a $(TARGET)
-	ar d $(TARGET) $(EXC_OBJS)
-	ar r $(TARGET) $(OBJS)
-	ranlib $(TARGET)
+all: $(TARGET)
+
+$(TARGET): $(OBJS)
+	@if [ -f "$(LIBGMP)" ]; then \
+	cp "$(LIBGMP)" $@ && \
+	ar d $@ $(EXC_OBJS); \
+	else \
+	echo "Warning: libgmp.a not found; creating minimal $(TARGET)"; \
+	ar rc $@; \
+	fi
+	ar r $@ $(OBJS)
+	ranlib $@
 
 clean:
 	rm -f $(OBJS) *~


### PR DESCRIPTION
## Summary
- fix detection of libgcc object names on 64‑bit toolchains
- allow building without a system `libgmp.a`

## Testing
- `make` *(fails: No 'ghc-6.8.2' directory found)*