### PR TITLE
Add doc roadmap and Sphinx package

### DIFF
--- a/docs/ROADMAP_DOCUMENTATION.md
+++ b/docs/ROADMAP_DOCUMENTATION.md
@@ -1,0 +1,28 @@
+# Documentation Roadmap
+
+This file outlines a tentative plan for documenting the `house` codebase.  The repository currently lacks a comprehensive documentation system.  This roadmap summarizes future work needed to generate API references and design notes.
+
+## Goals
+
+- Integrate [Doxygen](https://www.doxygen.nl/) for C and Haskell bindings.
+- Build HTML docs using [Sphinx](https://www.sphinx-doc.org/) for narrative guides.
+- Avoid modifying original features while adding architecture notes.
+- Create an `arch/x86_64_v1` directory as a placeholder for a future 64‑bit port.
+
+## Tasks
+
+1. **Set up tooling**
+   - Ensure the `setup.sh` script installs `doxygen` and `python3-sphinx`.
+   - Add `docs/Doxyfile` and `docs/conf.py` templates.
+2. **Scan sources**
+   - Identify undocumented functions under `kernel/`, `net/`, `support/`, and `tests/`.
+   - Add `/** */` style comments with summaries, parameters, and return values.
+3. **Generate docs**
+   - Run `doxygen docs/Doxyfile` to produce API documentation.
+   - Build Sphinx HTML docs with `sphinx-build docs docs/_build`.
+4. **Architecture port**
+   - Create `arch/x86_64_v1/` for a future port.  Copy existing IA32 files as a starting point.
+   - Document assumptions and missing features.
+
+This roadmap is intentionally high level; actual implementation depends on
+upstream design decisions.

--- a/patches/house/configure_alignment.patch
+++ b/patches/house/configure_alignment.patch
@@ -1,0 +1,12 @@
+diff -u ghc-xen/configure.ac ghc-house/configure.ac
+--- ghc-xen/configure.ac	2025-06-06 20:25:33.348048765 +0000
++++ ghc-house/configure.ac	2025-06-06 20:25:37.624095895 +0000
+@@ -3,7 +3,7 @@
+ FP_CHECK_ALIGNMENT(unsigned long long)
+ fi
+ FP_CHECK_ALIGNMENT(unsigned short)
+-FP_CHECK_ALIGNMENT(void *)
++FP_CHECK_ALIGNMENT([void *])
+ 
+ FP_CHECK_FUNC([WinExec],
+   [@%:@include <windows.h>], [WinExec("",0)])

--- a/scripts/analyze_ipc.py
+++ b/scripts/analyze_ipc.py
@@ -1,0 +1,24 @@
+import os
+import re
+
+# Walk repository and collect lines containing 'IPC' or 'fast bin' mention
+TARGET_PATTERNS = [re.compile(rb"\bIPC\b"), re.compile(rb"fast\s*bin", re.I)]
+
+results = []
+for root, dirs, files in os.walk('.', followlinks=False):
+    for f in files:
+        if not f.endswith(('.c', '.h', '.hs', '.lhs')):
+            continue
+        path = os.path.join(root, f)
+        try:
+            with open(path, 'rb') as fh:
+                for idx, line in enumerate(fh, 1):
+                    for pat in TARGET_PATTERNS:
+                        if pat.search(line):
+                            results.append((path, idx, line.decode('utf-8', 'ignore').rstrip()))
+                            break
+        except FileNotFoundError:
+            continue
+
+for path, line_no, text in results:
+    print(f"{path}:{line_no}: {text}")

--- a/setup.sh
+++ b/setup.sh
@@ -62,7 +62,7 @@ base_pkgs=(
   llvm-bolt
   qemu-system-x86 qemu-utils afl++
   cabal-install hlint shellcheck
-  graphviz doxygen pandoc
+  graphviz doxygen pandoc python3-sphinx
   coq isabelle tlaplus agda
   nodejs npm
   libcapnproto-dev


### PR DESCRIPTION
## Summary
- outline a roadmap for future documentation work
- add `python3-sphinx` to the setup script for documentation tools

## Testing
- `python3 scripts/analyze_ipc.py | head -n 5`
- `make boot`
- `make` *(fails: autoreconf missing and later GHC dir not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433ea9309883318c9d47f486f03215